### PR TITLE
ROOT CMake macro check and Marlin BOOK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,15 +13,18 @@ SET( ${PROJECT_NAME}_VERSION_MAJOR 1 )
 SET( ${PROJECT_NAME}_VERSION_MINOR 16 )
 SET( ${PROJECT_NAME}_VERSION_PATCH 0 )
 
-
+LIST( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 
 ### DEPENDENCIES ############################################################
-
-FIND_PACKAGE( ILCUTIL COMPONENTS ILCSOFT_CMAKE_MODULES streamlog ILCTEST REQUIRED )
-#FIND_PACKAGE( ILCSOFT_CMAKE_MODULES 1.11 REQUIRED )
-
+FIND_PACKAGE( ILCUTIL COMPONENTS ILCSOFT_CMAKE_MODULES streamlog REQUIRED )
 # load default settings from ILCSOFT_CMAKE_MODULES
+# nasty feature of iLCUtil: switch this OFF
+SET( USE_CXX11 OFF )
 INCLUDE( ilcsoft_default_settings )
+IF( NOT CMAKE_CXX_STANDARD )
+  # minimum standard required
+  SET( CMAKE_CXX_STANDARD 17 )
+ENDIF()
 
 
 # required packages
@@ -35,15 +38,33 @@ SET( Marlin_DEPENDS_LIBRARIES ${LCIO_LIBRARIES} ${streamlog_LIBRARIES} )
 
 INCLUDE_DIRECTORIES( SYSTEM ${Marlin_DEPENDS_INCLUDE_DIRS} )
 
+OPTION( MARLIN_BOOK  "Set to ON to build Marlin with book store functionality (requires ROOT7 !)" OFF )
 OPTION( MARLIN_DD4HEP "Set to ON to build Marlin with DD4hep" ON )
+
+IF( MARLIN_BOOK )
+  LIST( APPEND ROOT_COMPONENTS Core Hist RIO )
+  ADD_DEFINITIONS( -DMARLIN_BOOK )
+ENDIF()
+
 IF( MARLIN_DD4HEP )
-    FIND_PACKAGE( ROOT REQUIRED )
-    FIND_PACKAGE( DD4hep COMPONENTS DDRec DDParsers )
+  LIST( APPEND ROOT_COMPONENTS Geom Eve )
+ENDIF( )
+
+IF( ROOT_COMPONENTS )
+  # activate ROOT verbosity
+  SET( ROOT_CONFIG_DEBUG True )
+  # this already imports include directories, libraries
+  FIND_PACKAGE( ROOT 6.18 COMPONENTS ${ROOT_COMPONENTS} REQUIRED )
+  # check ROOT requirements
+  INCLUDE( MarlinCheckROOTRequirements )
+  MarlinCheckROOTRequirements()
+ENDIF()
+
+
+IF( MARLIN_DD4HEP )
+    FIND_PACKAGE( DD4hep COMPONENTS DDRec DDParsers REQUIRED )
     IF( NOT DD4hep_FOUND )
         MESSAGE( SEND_ERROR "DD4hep not found. Please set MARLIN_DD4HEP to OFF or DD4hep_DIR=/path/to/DD4hep" )
-    ENDIF()
-    IF( NOT ROOT_FOUND )
-        MESSAGE( SEND_ERROR "ROOT not found. Please set MARLIN_DD4HEP to OFF or ROOT_DIR=/path/to/ROOT" )
     ENDIF()
 ENDIF()
 

--- a/cmake/MarlinCheckROOTRequirements.cmake
+++ b/cmake/MarlinCheckROOTRequirements.cmake
@@ -1,0 +1,53 @@
+# 
+# CMake macro(s) to check if the detected ROOT 
+# version fulfill our requirements 
+# 
+# @author: Remi Ete, DESY
+# @date: Oct 2019
+# 
+
+
+function( MarlinCheckROOTRequirements )
+  # check if find_package( ROOT ... ) was processed before
+  if( NOT ROOT_FOUND OR NOT ROOT_INCLUDE_DIRS )
+    message( FATAL_ERROR "ROOT not found. Couldn't check ROOT7 requirements. Please use find_package( ROOT ... ) before calling this function" )
+  endif()
+  if( NOT MARLIN_BOOK )
+    return()
+  endif()
+  # Marlin book requires includes from ROOT 7
+  list( APPEND REQUIRED_INCLUDES
+    RHist.hxx
+    RSpan.hxx
+    RAxis.hxx
+    RHistBufferedFill.hxx
+    RHistConcurrentFill.hxx
+  )
+  foreach( include_dir ${ROOT_INCLUDE_DIRS} )
+    foreach( include_file ${REQUIRED_INCLUDES} )
+      string( REPLACE "." "_" include_file_var ${include_file} )
+      find_file( file_found_${include_file_var} ${include_file} PATHS ${include_dir} PATH_SUFFIXES ROOT NO_DEFAULT_PATH )    
+      message( STATUS " => Checking for file ${include_file}: ${file_found_${include_file_var}}" )
+      if( NOT file_found_${include_file_var} )
+        message( FATAL_ERROR "Couldn't find ROOT header file: ${include_file}" )
+      endif()
+    endforeach()
+  endforeach()
+  # Required ROOT options
+  set( REQUIRED_OPTIONS root7 )
+  foreach( opt ${REQUIRED_OPTIONS} )
+    message( STATUS " => Checking for ROOT option ${opt}: ${ROOT_${opt}_FOUND}" )
+    if( NOT ROOT_${opt}_FOUND )
+      message( FATAL_ERROR "Marlin ROOT requirements: ROOT was not compiled with the option '${opt}'" )
+    endif()
+  endforeach()
+  message( STATUS "Marlin ROOT requirements OK ..." )
+endfunction()
+
+
+
+
+
+
+
+


### PR DESCRIPTION

BEGINRELEASENOTES
- Introduced CMake option `MARLIN_BOOK` to switch ON future compilation of the book component.
- Added ROOT package checks (only for MARLIN_BOOK=ON):
    - Looks for `root7` option in ROOT
    - Looks for a specific list of headers needed for Marlin book 
- Added pre-processor variable `-DMARLIN_BOOK` to compilation if option is ON

ENDRELEASENOTES