### PR TITLE
Wrong destination type for thismarlin.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/MarlinConfig.h.cmake.in"
 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/thismarlin.sh.in"
     "${PROJECT_BINARY_DIR}/thismarlin.sh" @ONLY )
 
-INSTALL( FILES "${PROJECT_BINARY_DIR}/thismarlin.sh" DESTINATION ${CMAKE_INSTALL_BINDIR} )
+INSTALL( FILES "${PROJECT_BINARY_DIR}/thismarlin.sh" DESTINATION bin )
 
 INSTALL( FILES "${PROJECT_BINARY_DIR}/marlin/MarlinConfig.h" DESTINATION "include/marlin/" )
 INSTALL( FILES "${PROJECT_SOURCE_DIR}/source/python/compareMarlinSteeringFiles.py" DESTINATION "bin"


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed wrong usage of binary destination for `thismarlin.sh` script

ENDRELEASENOTES