### PR TITLE
TravisCI setup and unit test bug fix

### DIFF
--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -6,8 +6,8 @@ cd Package
 mkdir build
 cd build
 # TODO enable 'warning as error' asap
-cmake -GNinja \
-  -C ../../CMakeCache.cmake 
+cmake \
+  -C ../../CMakeCache.cmake \
   -DCMAKE_INSTALL_PREFIX=$PWD/../install \
   -DCMAKE_CXX_STANDARD=17 \
   -DMARLIN_BOOK=ON \
@@ -15,7 +15,6 @@ cmake -GNinja \
   -DMARLIN_DD4HEP=ON \
   -DMARLIN_GEAR=ON \
   -DBUILD_TESTING=ON \
-  ../../../local/soft/MarlinMT && \
-ninja -k0 && \
-ninja install && \
+  .. && \
+make install && \
 ctest --output-on-failure

--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-source setup.sh
+source $HOME/setup.sh
 
-cd Package
+cd /Package
 mkdir build
 cd build
 # TODO enable 'warning as error' asap
 cmake \
-  -C ../../CMakeCache.cmake \
+  -C $HOME/CMakeCache.cmake \
   -DCMAKE_INSTALL_PREFIX=$PWD/../install \
   -DCMAKE_CXX_STANDARD=17 \
   -DMARLIN_BOOK=ON \

--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 
-ILCSOFT=/cvmfs/clicdp.cern.ch/iLCSoft/builds/current/CI_${COMPILER}
-source $ILCSOFT/init_ilcsoft.sh
+source setup.sh
 
-cd /Package
+cd Package
 mkdir build
 cd build
-cmake -GNinja -C $ILCSOFT/ILCSoft.cmake -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror" .. && \
+# TODO enable 'warning as error' asap
+cmake -GNinja \
+  -C ../../CMakeCache.cmake 
+  -DCMAKE_INSTALL_PREFIX=$PWD/../install \
+  -DCMAKE_CXX_STANDARD=17 \
+  -DMARLIN_BOOK=ON \
+  -DMARLIN_LCIO=ON \
+  -DMARLIN_DD4HEP=ON \
+  -DMARLIN_GEAR=ON \
+  -DBUILD_TESTING=ON \
+  ../../../local/soft/MarlinMT && \
 ninja -k0 && \
 ninja install && \
 ctest --output-on-failure

--- a/.travis-ci.d/coverity_scan.sh
+++ b/.travis-ci.d/coverity_scan.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# TODO: Should we run coverity scan ? To be investigated...
+exit
 ILCSOFT=/cvmfs/clicdp.cern.ch/iLCSoft/builds/current/CI_${COMPILER}
 source $ILCSOFT/init_ilcsoft.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,15 @@ services:
 
 language: cpp
 
-# command to install dependencies
-install:
-  - mkdir Package
-  - mv !(Package) Package
-  - export PKGDIR=${PWD}/Package
-
 # command to run tests
 script:
-  - docker run -it --name CI_container -v $PKGDIR:/home/ilc/Package -d rete/marlinmt-ci
-  - docker exec -it CI_container /bin/bash -c "./Package/.travis-ci.d/compile_and_test.sh"
+  - shopt -s extglob dotglob
+  - mkdir Package
+  - mv !(Package) Package
+  - shopt -u dotglob
+  - export PKGDIR=${PWD}/Package
+  - docker run -it --name CI_container -v $PKGDIR:/Package -d rete/marlinmt-ci
+  - docker exec -it CI_container /bin/bash -c "/Package/.travis-ci.d/compile_and_test.sh"
 
 # Don't send e-mail notifications
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,58 +6,16 @@ services:
 
 language: cpp
 
-env:
-  matrix:
-    - COMPILER=gcc
-    - COMPILER=llvm
-
-
-before_install:
-  - wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
-  - sudo dpkg -i cvmfs-release-latest_all.deb
-  - sudo apt-get update
-  - sudo apt-get install cvmfs cvmfs-config-default
-  - rm -f cvmfs-release-latest_all.deb
-  - wget https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
-  - sudo mkdir -p /etc/cvmfs
-  - sudo mv default.local /etc/cvmfs/default.local
-  - sudo /etc/init.d/autofs stop
-  - sudo cvmfs_config setup
-  - sudo mkdir -p /cvmfs/clicdp.cern.ch
-  - sudo mount -t cvmfs clicdp.cern.ch /cvmfs/clicdp.cern.ch
-  - ls /cvmfs/clicdp.cern.ch
-
 # command to install dependencies
 install:
-  - shopt -s extglob dotglob
   - mkdir Package
   - mv !(Package) Package
-  - shopt -u dotglob
   - export PKGDIR=${PWD}/Package
-  - export description=`date`
-  - export COVERITY_REPO=`echo ${TRAVIS_REPO_SLUG} | sed 's/\//\%2F/g'`
-  - if [[ "${TRAVIS_EVENT_TYPE}" == "cron" && "${COMPILER}" == "gcc"  ]];
-    then wget https://scan.coverity.com/download/linux64 --post-data "token=${COVERITY_SCAN_TOKEN}&project=${COVERITY_REPO}" -O Package/coverity_tool.tgz; cd Package; mkdir cov-analysis-linux64; tar -xf coverity_tool.tgz -C cov-analysis-linux64 --strip-components=1;
-    fi
 
 # command to run tests
 script:
-  - docker run -it --name CI_container -v $PKGDIR:/Package -e COMPILER=$COMPILER -v /cvmfs/clicdp.cern.ch:/cvmfs/clicdp.cern.ch -d clicdp/slc6-build /bin/bash
-  - if [[ "${TRAVIS_EVENT_TYPE}" == "cron" && "${COMPILER}" == "gcc"  ]];
-    then docker exec -it CI_container /bin/bash -c "./Package/.travis-ci.d/coverity_scan.sh";
-    elif [[ "${TRAVIS_EVENT_TYPE}" == "cron" && "${COMPILER}" == "llvm"  ]];
-    then echo "Running the weekly Coverity Scan, no LLVM/Clang build this time";
-    else docker exec -it CI_container /bin/bash -c "./Package/.travis-ci.d/compile_and_test.sh";
-    fi
-  - if [[ "${TRAVIS_EVENT_TYPE}" == "cron" && "${COMPILER}" == "gcc"  ]];
-    then curl --form token=${COVERITY_SCAN_TOKEN} --form email=noreply@cern.ch --form file=@${PKGDIR}/build/myproject.tgz --form version="master" --form description="${description}" https://scan.coverity.com/builds?project=${COVERITY_REPO} ;
-    fi
-
-# Trigger to rebuild iLCSoft
-after_success:
-  - if [[ "${TRAVIS_EVENT_TYPE}" != "cron" && "${TRAVIS_EVENT_TYPE}" != "pull_request" && "${COMPILER}" == "gcc" && "${TRAVIS_REPO_SLUG%/*}" == "iLCSoft" && -z ${TRAVIS_TAG} ]];
-    then curl -X POST -F token=$GITLAB_TOKEN -F ref=master https://gitlab.cern.ch/api/v4/projects/7828/trigger/pipeline;
-    fi
+  - docker run -it --name CI_container -v $PKGDIR:/home/ilc/Package -d rete/marlinmt-ci
+  - docker exec -it CI_container /bin/bash -c "./Package/.travis-ci.d/compile_and_test.sh"
 
 # Don't send e-mail notifications
 notifications:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,7 +68,7 @@ marlin_add_processor_test (
   STEERING_FILE ${CMAKE_CURRENT_SOURCE_DIR}/steer/eventmodifier.xml
   INPUT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/simjob.slcio
   REGEX_PASS "TestEventModifier modified 3 events in 1 run"
-  MARLIN_DLL Marlin::LCIOPlugins
+  MARLIN_DLL Marlin::CorePlugins Marlin::LCIOPlugins
 )
 
 marlin_add_processor_test (
@@ -77,7 +77,7 @@ marlin_add_processor_test (
   INPUT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/simjob.slcio
   REGEX_PASS "TestProcessorEventSeeder failed to register processor to event seed generator"
   REGEX_FAIL "ERROR .TestProcessorEventSeeder.* Seeds don't match"
-  MARLIN_DLL Marlin::LCIOPlugins
+  MARLIN_DLL Marlin::CorePlugins Marlin::LCIOPlugins
 )
 
 marlin_add_processor_test (
@@ -88,5 +88,5 @@ marlin_add_processor_test (
     ${CMAKE_CURRENT_SOURCE_DIR}/steer/include-eventmodifier.xml
     ${CMAKE_CURRENT_SOURCE_DIR}/steer/constants-eventmodifier.xml
   REGEX_PASS "TestEventModifier modified 3 events in 1 run"
-  MARLIN_DLL Marlin::LCIOPlugins
+  MARLIN_DLL Marlin::CorePlugins Marlin::LCIOPlugins
 )


### PR DESCRIPTION
BEGINRELEASENOTES
- Updated Travis-ci script to pull ready-to-go image for CI
   - Use image `rete/marlinmt-ci` with specific branches of LCIO, SIO, ROOT (root7)
- Switched OFF coverity scan for the time being
- Fixed missing Marlin::CorePlugins DLL for processor unit tests

ENDRELEASENOTES