### PR TITLE
Plugin manager: library name and generic plugin

### DIFF
--- a/source/framework/CMakeLists.txt
+++ b/source/framework/CMakeLists.txt
@@ -96,6 +96,7 @@ set( MarlinMT_BINARIES MarlinShellCompletion MarlinDumpPlugins Marlin MarlinMT )
 foreach( binary ${MarlinMT_BINARIES} )
   add_executable( bin_${binary} main/${binary}.cc )
   target_link_libraries( bin_${binary} Marlin::Core )
+  set_target_properties( bin_${binary} PROPERTIES OUTPUT_NAME ${binary} )
   install( TARGETS bin_${binary} RUNTIME )
 endforeach()
 

--- a/source/framework/include/marlin/PluginManager.h
+++ b/source/framework/include/marlin/PluginManager.h
@@ -38,6 +38,9 @@
 #define MARLIN_DECLARE_DATASOURCE_NAME( Class, NameStr ) MARLIN_DECLARE_PLUGIN( Class, NameStr, marlin::PluginType::DataSource )
 #define MARLIN_DECLARE_DATASOURCE( Class ) MARLIN_DECLARE_DATASOURCE_NAME( Class, #Class )
 
+// generic plugin declaration
+#define MARLIN_DECLARE_GENERIC( Class, NameStr ) MARLIN_DECLARE_PLUGIN( Class, NameStr, marlin::PluginType::GenericPlugin )
+
 namespace marlin {
 
   /**
@@ -48,7 +51,8 @@ namespace marlin {
   enum class PluginType : int {
     Processor,
     GeometryPlugin,
-    DataSource
+    DataSource,
+    GenericPlugin
   } ;
 
   //--------------------------------------------------------------------------
@@ -159,6 +163,14 @@ namespace marlin {
      */
     template <typename T>
     std::shared_ptr<T> create( PluginType type, const std::string &name ) const ;
+    
+    /**
+     *  @brief  Create a new plugin instance. Shortcut for generic plugins
+     *
+     *  @param  name the plugin name
+     */
+    template <typename T>
+    std::shared_ptr<T> create( const std::string &name ) const ;
 
     /**
      *  @brief  Dump plugin manager content in console
@@ -218,6 +230,13 @@ namespace marlin {
     }
     auto pointer = factoryIter->second._factory() ; // factory function call
     return std::static_pointer_cast<T, void>( pointer ) ;
+  }
+  
+  //--------------------------------------------------------------------------
+  
+  template <typename T>
+  inline std::shared_ptr<T> PluginManager::create( const std::string &name ) const {
+    return create<T>( PluginType::GenericPlugin, name ) ;
   }
 
 } // end namespace marlin

--- a/source/framework/include/marlin/PluginManager.h
+++ b/source/framework/include/marlin/PluginManager.h
@@ -66,7 +66,15 @@ namespace marlin {
     // typedefs
     typedef std::shared_ptr<void>                       PluginPtr ;
     typedef std::function<PluginPtr()>                  FactoryFunction ;
-    typedef std::map<std::string, FactoryFunction>      FactoryMap ;
+    
+    struct FactoryData {
+      /// The name of the library of the plugin 
+      std::string           _libraryName {} ;
+      /// The plugin factory
+      FactoryFunction       _factory {} ;
+    };
+    
+    typedef std::map<std::string, FactoryData>          FactoryMap ;
     typedef std::map<PluginType, FactoryMap>            PluginFactoryMap ;
     typedef std::vector<void*>                          LibraryList ;
     typedef Logging::Logger                             Logger ;
@@ -179,6 +187,8 @@ namespace marlin {
     mutable Logger             _logger {nullptr} ;
     /// The synchronization mutex
     mutable mutex_type         _mutex {} ;
+    /// The current library being loaded
+    std::string                _currentLibrary {} ;
   };
 
   //--------------------------------------------------------------------------
@@ -206,7 +216,7 @@ namespace marlin {
       _logger->log<DEBUG5>() << "Plugin not found: type '" << typeStr << "', name '" << name << "'" << std::endl ;
       return nullptr ;
     }
-    auto pointer = factoryIter->second() ; // factory function call
+    auto pointer = factoryIter->second._factory() ; // factory function call
     return std::static_pointer_cast<T, void>( pointer ) ;
   }
 

--- a/source/framework/src/PluginManager.cc
+++ b/source/framework/src/PluginManager.cc
@@ -16,6 +16,7 @@ namespace marlin {
     _pluginFactories.insert( PluginFactoryMap::value_type(PluginType::Processor, FactoryMap()) ) ;
     _pluginFactories.insert( PluginFactoryMap::value_type(PluginType::GeometryPlugin, FactoryMap()) ) ;
     _pluginFactories.insert( PluginFactoryMap::value_type(PluginType::DataSource, FactoryMap()) ) ;
+    _pluginFactories.insert( PluginFactoryMap::value_type(PluginType::GenericPlugin, FactoryMap()) ) ;
     _logger = Logging::createLogger( "PluginManager" ) ;
     _logger->setLevel<MESSAGE>() ;
   }
@@ -136,6 +137,7 @@ namespace marlin {
       case PluginType::Processor: return "Processor" ;
       case PluginType::GeometryPlugin: return "GeometryPlugin" ;
       case PluginType::DataSource: return "DataSource" ;
+      case PluginType::GenericPlugin: return "GenericPlugin" ;
       default: throw;
     }
   }

--- a/source/framework/src/PluginManager.cc
+++ b/source/framework/src/PluginManager.cc
@@ -35,7 +35,10 @@ namespace marlin {
       _logger->log<DEBUG2>() << "PluginManager::registerPlugin: plugin '" << name << "' already registered! Skipping ..." << std::endl ;
     }
     else {
-      typeIter->second.insert( FactoryMap::value_type( name, factoryFunction ) ) ;
+      FactoryData fdata {} ;
+      fdata._libraryName = _currentLibrary ;
+      fdata._factory = factoryFunction ;
+      typeIter->second.insert( FactoryMap::value_type( name, fdata ) ) ;
       auto typeStr = pluginTypeToString( type ) ;
       _logger->log<DEBUG5>() << "New plugin registered: type '" << typeStr << "', name '" << name << "'" <<std::endl ;
     }
@@ -92,7 +95,9 @@ namespace marlin {
             << "    ->    Trying to load DUPLICATE library -->" << std::endl << std::endl ;
         return false ;
       }
+      _currentLibrary = library ;
       void* libPointer = dlopen( library.c_str() , RTLD_LAZY | RTLD_GLOBAL) ;
+      _currentLibrary.clear() ;
       if( nullptr == libPointer ) {
         _logger->log<ERROR>() << std::endl << "<!-- ERROR loading shared library : " << library << std::endl
                     << "    ->    "   << dlerror() << " -->" << std::endl << std::endl ;
@@ -117,7 +122,7 @@ namespace marlin {
       else {
         _logger->log<MESSAGE>() << " " << typeStr << " plugins:" << std::endl ;
         for ( auto iter : pluginIter.second ) {
-          _logger->log<MESSAGE>() << " - " << iter.first << std::endl ;
+          _logger->log<MESSAGE>() << " - " << iter.first << " [" << iter.second._libraryName << "]" << std::endl ;
         }
       }
     }


### PR DESCRIPTION
BEGINRELEASENOTES
- Framework
   + Added library name to plugin printout
   + Added new plugin type `GenericPlugin` for plugin types not fitting anywhere
   + Bug fix: added missing `OUTPUT_NAME` properties to all framework binaries

ENDRELEASENOTES